### PR TITLE
use hard-coded build date for RocksDB

### DIFF
--- a/arangodb.cmake
+++ b/arangodb.cmake
@@ -67,3 +67,8 @@ if (MSVC)
 endif ()
 set(USE_RTTI ON CACHE BOOL "enable RTTI")
 
+# note: the actual timestamp does not matter here. we only want it to be
+# a fixed value, so that building at different timestamps produces the same
+# binary executable and build id. 
+# the build date of RocksDB is not used by ArangoDB at all.
+set(BUILD_DATE "2024-06-10 17:48:39" CACHE STRING "the time we first built rocksdb")


### PR DESCRIPTION
so that repeated builds with the same source code produce the same binary executable.
note that the now-hard coded build date is not used by ArangoDB at all, so its actual value does not matter, as long as it is hard-coded.