### PR TITLE
fix io uring fd leak

### DIFF
--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -265,6 +265,7 @@ const unsigned int kIoUringDepth = 256;
 
 inline void DeleteIOUring(void* p) {
   struct io_uring* iu = static_cast<struct io_uring*>(p);
+  io_uring_queue_exit(iu);
   delete iu;
 }
 


### PR DESCRIPTION
Fixes https://arangodb.atlassian.net/browse/ES-2813.
This patch was forgotten for new RocksDB.
I am writing a document for RocksDB upgrades and adding this to it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures proper cleanup of `io_uring` resources to prevent FD leaks.
> 
> - In `env/io_posix.h`, `DeleteIOUring` now calls `io_uring_queue_exit(iu)` before deleting the `io_uring` instance (only when `ROCKSDB_IOURING_PRESENT`).
> - Scope limited to cleanup path; no API/behavioral changes beyond resource management.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit feda96e1de750739a7509501e0a42c56095d2b54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->